### PR TITLE
fixes #145

### DIFF
--- a/src/api/backup.js
+++ b/src/api/backup.js
@@ -4,11 +4,11 @@ exports.list = {
   apiKeyRequired: true,
   parameters: {
     SUBID: {
-      type: Number,
+      type: 'number',
       optional: true
     },
     BACKUPID: {
-      type: String,
+      type: 'string',
       optional: true
     }
   }

--- a/src/api/block.js
+++ b/src/api/block.js
@@ -4,15 +4,15 @@ exports.attach = {
   apiKeyRequired: true,
   parameters: {
     SUBID: {
-      type: Number,
+      type: 'number',
       optional: false
     },
     attach_to_SUBID: {
-      type: Number,
+      type: 'number',
       optional: false
     },
     live: {
-      type: String,
+      type: 'string',
       optional: true
     }
   }
@@ -24,15 +24,15 @@ exports.create = {
   apiKeyRequired: true,
   parameters: {
     DCID: {
-      type: Number,
+      type: 'number',
       optional: false
     },
     size_gb: {
-      type: Number,
+      type: 'number',
       optional: false
     },
     label: {
-      type: String,
+      type: 'string',
       optional: true
     }
   }
@@ -44,7 +44,7 @@ exports.delete = {
   apiKeyRequired: true,
   parameters: {
     SUBID: {
-      type: Number,
+      type: 'number',
       optional: false
     }
   }

--- a/src/api/plans.js
+++ b/src/api/plans.js
@@ -4,7 +4,7 @@ exports.list = {
   apiKeyRequired: true,
   parameters: {
     type: {
-      type: String,
+      type: 'string',
       optional: true
     }
   }

--- a/src/api/sshkey.js
+++ b/src/api/sshkey.js
@@ -10,11 +10,11 @@ exports.create = {
   apiKeyRequired: true,
   parameters: {
     name: {
-      type: String,
+      type: 'string',
       optional: true
     },
     ssh_key: {
-      type: String,
+      type: 'string',
       optional: false
     }
   }
@@ -26,7 +26,7 @@ exports.delete = {
   apiKeyRequired: true,
   parameters: {
     SSHKEYID: {
-      type: String,
+      type: 'string',
       optional: false
     }
   }
@@ -38,15 +38,15 @@ exports.update = {
   apiKeyRequired: true,
   parameters: {
     SSHKEYID: {
-      type: String,
+      type: 'string',
       optional: false
     },
     name: {
-      type: String,
+      type: 'string',
       optional: true
     },
     ssh_key: {
-      type: String,
+      type: 'string',
       optional: true
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,15 @@ exports.initialize = config => {
               ) {
                 throw new Error(`Missing parameter: ${parameter}`)
               } else if (parameters[parameter]) {
-                requestParameters[parameter] = parameters[parameter]
+                if (
+                  typeof parameters[parameter] !==
+                  // eslint-disable-next-line valid-typeof
+                  endpoint.parameters[parameter].type
+                ) {
+                  throw new Error(`Invalid parameter type: ${parameter}`)
+                } else {
+                  requestParameters[parameter] = parameters[parameter]
+                }
               }
             }
 


### PR DESCRIPTION
There's a few other open PRs we'll need to update once this goes through, since they still have `type: String` instead of `type: 'string'`, but this issue will allow us to make sure that it's not just the proper parameters, but also the proper type. With this, we can start testing the parameter types too in test cases. 