### PR TITLE
implements #43, adds missing test for plans/list

### DIFF
--- a/src/api/plans.js
+++ b/src/api/plans.js
@@ -9,3 +9,9 @@ exports.list = {
     }
   }
 }
+
+exports.listBareMetal = {
+  url: '/plans/list_baremetal',
+  requestType: 'GET',
+  apiKeyRequired: true
+}

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,8 @@ exports.initialize = config => {
       list: createRequestFunction(os.list)
     },
     plans: {
-      list: createRequestFunction(plans.list)
+      list: createRequestFunction(plans.list),
+      listBareMetal: createRequestFunction(plans.listBareMetal)
     },
     sshkey: {
       create: createRequestFunction(sshkey.create),

--- a/test/api/plans.test.js
+++ b/test/api/plans.test.js
@@ -1,0 +1,107 @@
+const expect = require('chai').expect
+const vultr = require('../../src/index')
+const config = require('../config')
+const nock = require('nock')
+
+const mock = {
+  list: {
+    '1': {
+      VPSPLANID: '1',
+      name: 'Starter',
+      vcpu_count: '1',
+      ram: '512',
+      disk: '20',
+      bandwidth: '1',
+      price_per_month: '5.00',
+      windows: false,
+      plan_type: 'SSD',
+      available_locations: [1, 2, 3]
+    },
+    '2': {
+      VPSPLANID: '2',
+      name: 'Basic',
+      vcpu_count: '1',
+      ram: '1024',
+      disk: '30',
+      bandwidth: '2',
+      price_per_month: '8.00',
+      windows: false,
+      plan_type: 'SATA',
+      available_locations: [],
+      deprecated: true
+    }
+  },
+  listBareMetal: {
+    '100': {
+      METALPLANID: '100',
+      name: '65536 MB RAM,2x 240 GB SSD,5.00 TB BW',
+      cpu_count: 1,
+      cpu_model: 'E3-1270v6',
+      ram: 65536,
+      disk: '2x 240 GB SSD',
+      bandwidth_tb: 5,
+      price_per_month: 100,
+      plan_type: 'SSD',
+      deprecated: false,
+      available_locations: [1, 2, 3]
+    }
+  }
+}
+
+describe('plans', () => {
+  describe('list()', () => {
+    beforeEach(() => {
+      nock('https://api.vultr.com', {
+        reqheaders: {
+          'API-Key': /[A-Z0-9]{36}/i
+        }
+      })
+        .get('/v1/plans/list')
+        .reply(200, mock.list)
+    })
+
+    it('requires an API key', () => {
+      const vultrInstance = vultr.initialize()
+      expect(() => {
+        vultrInstance.block.attach()
+      }).to.throw(Error)
+    })
+
+    it('gets the list of plans', () => {
+      const vultrInstance = vultr.initialize({ apiKey: config.apiKey })
+
+      return vultrInstance.plans.list().then(response => {
+        expect(typeof response).to.equal('object')
+        expect(response).to.deep.equal(mock.list)
+      })
+    })
+  })
+
+  describe('listBareMetal()', () => {
+    beforeEach(() => {
+      nock('https://api.vultr.com', {
+        reqheaders: {
+          'API-Key': /[A-Z0-9]{36}/i
+        }
+      })
+        .get('/v1/plans/list_baremetal')
+        .reply(200, mock.listBareMetal)
+    })
+
+    it('requires an API key', () => {
+      const vultrInstance = vultr.initialize()
+      expect(() => {
+        vultrInstance.block.attach()
+      }).to.throw(Error)
+    })
+
+    it('gets the list of bare metal plans', () => {
+      const vultrInstance = vultr.initialize({ apiKey: config.apiKey })
+
+      return vultrInstance.plans.listBareMetal().then(response => {
+        expect(typeof response).to.equal('object')
+        expect(response).to.deep.equal(mock.listBareMetal)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Looks like when I was creating the skeleton, I never made a test for plans/list, so I added that in this commit since I needed to test the new bare metal endpoint as well. 