### PR TITLE
Vdc2 plans

### DIFF
--- a/src/api/plans.js
+++ b/src/api/plans.js
@@ -21,3 +21,9 @@ exports.listVc2 = {
   requestType: 'GET',
   apiKeyRequired: false
 }
+
+exports.listVdc2 = {
+  url: '/plans/list_vdc2',
+  requestType: 'GET',
+  apiKeyRequired: false
+}

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,8 @@ exports.initialize = config => {
     plans: {
       list: createRequestFunction(plans.list),
       listBareMetal: createRequestFunction(plans.listBareMetal),
-      listVc2: createRequestFunction(plans.listVc2)
+      listVc2: createRequestFunction(plans.listVc2),
+      listVdc2: createRequestFunction(plans.listVdc2)
     },
     regions: {
       list: createRequestFunction(regions.list)

--- a/test/api/plans.test.js
+++ b/test/api/plans.test.js
@@ -57,6 +57,18 @@ const mock = {
       price_per_month: '5.00',
       plan_type: 'SSD'
     }
+  },
+  listVdc2: {
+    '115': {
+      VPSPLANID: '115',
+      name: '8192 MB RAM,110 GB SSD,10.00 TB BW',
+      vcpu_count: '2',
+      ram: '8192',
+      disk: '110',
+      bandwidth: '10.00',
+      price_per_month: '60.00',
+      plan_type: 'DEDICATED'
+    }
   }
 }
 
@@ -135,6 +147,32 @@ describe('plans', () => {
       return vultrInstance.plans.listVc2().then(response => {
         expect(typeof response).to.equal('object')
         expect(response).to.deep.equal(mock.listVc2)
+      })
+    })
+  })
+
+  describe('listVdc2()', () => {
+    beforeEach(() => {
+      nock(config.baseUrl)
+        .get('/v1/plans/list_vdc2')
+        .reply(200, mock.listVdc2)
+    })
+
+    it('does not require an API key', () => {
+      const vultrInstance = vultr.initialize()
+
+      return vultrInstance.plans.listVdc2().then(response => {
+        expect(typeof response).to.equal('object')
+        expect(response).to.deep.equal(mock.listVdc2)
+      })
+    })
+
+    it('gets a list of all active vdc2 plans', () => {
+      const vultrInstance = vultr.initialize()
+
+      return vultrInstance.plans.listVdc2().then(response => {
+        expect(typeof response).to.equal('object')
+        expect(response).to.deep.equal(mock.listVdc2)
       })
     })
   })


### PR DESCRIPTION
implements #45 and removes API key requirements from plans endpoints and tests.