### PR TITLE
fix package name on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NodeVultr
+# vultr-node
 
 Official Vultr client node module.
 


### PR DESCRIPTION
## Description
Changes the package name from `NodeVultr` to `vultr-node` on the README to reflect the package's name on NPM. 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you linted your code locally prior to submission?
* [ ] Have you successfully ran tests with your changes locally?
