### PR TITLE
fix renamed func in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ const vultr = VultrNode.initialize({
 ### Calling Endpoints
 ```js
 // Call endpoints using Promises
-vultr.account.info().then(response => {
+vultr.account.getInfo().then(response => {
   console.log(response)
 })
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
account.info was renamed to account.getInfo, updating the readme to avoid confusion.