### PR TITLE
replace request with node-fetch, fix getHealthCheckInfo false positive tests

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   singleQuote: true,
   semi: false,
+  trailingComma: 'none'
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,18 +258,6 @@
         }
       }
     },
-    "@babel/generator": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.9.5",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
-        "source-map": "^0.5.0"
-      }
-    },
     "@babel/helper-annotate-as-pure": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
@@ -750,26 +738,6 @@
         }
       }
     },
-    "@babel/helper-function-name": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.9.5"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.8.3"
-      }
-    },
     "@babel/helper-hoist-variables": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz",
@@ -796,48 +764,6 @@
             "to-fast-properties": "^2.0.0"
           }
         }
-      }
-    },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
-        "@babel/helper-simple-access": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/template": "^7.8.6",
-        "@babel/types": "^7.9.0",
-        "lodash": "^4.17.13"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -995,37 +921,6 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
-      }
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.8.3"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -3191,51 +3086,6 @@
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
-      }
-    },
-    "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.5",
-        "@babel/helper-function-name": "^7.9.5",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.5",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.13"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "@babel/types": {
@@ -6167,6 +6017,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-releases": {
       "version": "1.1.57",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "prettier": "^2.0.5"
   },
   "dependencies": {
+    "node-fetch": "^2.6.0",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7"
   },

--- a/src/api/load-balancer.js
+++ b/src/api/load-balancer.js
@@ -338,6 +338,10 @@ exports.setHealthCheck = {
       type: 'string',
       required: false
     },
+    port: {
+      type: 'number',
+      required: false
+    },
     check_interval: {
       type: 'number',
       required: false

--- a/src/util.js
+++ b/src/util.js
@@ -1,23 +1,49 @@
 exports.makeApiRequest = (config, endpoint, parameters) => {
-  const rp = require('request-promise-native')
+  const nf = require('node-fetch')
   const baseUrl = (config && config.baseUrl) || 'https://api.vultr.com/v1'
+  let fetchUrl = `${baseUrl}${endpoint.url}`
   const options = {
     method: endpoint.requestType,
-    url: `${baseUrl}${endpoint.url}`,
     headers: {
       'API-Key': (config && config.apiKey) || ''
-    },
-    qs: endpoint.requestType === 'GET' && parameters ? parameters : {},
-    form: endpoint.requestType === 'POST' && parameters ? parameters : {},
-    json: true,
-    timeout: config ? config.rateLimit : 700
+    }
   }
 
-  return rp(options)
-    .then(response => {
-      return response
+  if (parameters !== undefined) {
+    if (endpoint.requestType === 'POST') {
+      options.body = JSON.stringify(parameters)
+    } else if (endpoint.requestType === 'GET') {
+      const params = new URLSearchParams()
+      const userParams = Object.keys(parameters)
+
+      userParams.forEach((key) => {
+        params.append(key, parameters[key])
+      })
+      fetchUrl = `${fetchUrl}?${params}`
+    }
+  }
+
+  return nf(fetchUrl, options)
+    .then((response) => {
+      // The request was not successful
+      if (!response.ok) {
+        throw Error(response.statusText)
+      }
+
+      const contentType = response.headers.get('content-type')
+
+      // The request was successful, but does not return any data
+      if (!contentType || !contentType.includes('application/json')) {
+        return
+      }
+
+      // The request was successful and contains JSON data
+      return response.json().then((responseJSON) => {
+        return responseJSON
+      })
     })
-    .catch(error => {
-      return error
+    .catch((err) => {
+      console.error(err)
+      return err
     })
 }

--- a/src/util.js
+++ b/src/util.js
@@ -10,15 +10,16 @@ exports.makeApiRequest = (config, endpoint, parameters) => {
   }
 
   if (parameters !== undefined) {
-    if (endpoint.requestType === 'POST') {
-      options.body = JSON.stringify(parameters)
-    } else if (endpoint.requestType === 'GET') {
-      const params = new URLSearchParams()
-      const userParams = Object.keys(parameters)
+    const params = new URLSearchParams()
+    const userParams = Object.keys(parameters)
 
-      userParams.forEach((key) => {
-        params.append(key, parameters[key])
-      })
+    userParams.forEach((key) => {
+      params.append(key, parameters[key])
+    })
+
+    if (endpoint.requestType === 'POST') {
+      options.body = params
+    } else if (endpoint.requestType === 'GET') {
       fetchUrl = `${fetchUrl}?${params}`
     }
   }
@@ -43,7 +44,6 @@ exports.makeApiRequest = (config, endpoint, parameters) => {
       })
     })
     .catch((err) => {
-      console.error(err)
       return err
     })
 }

--- a/test/api/load-balancer.test.js
+++ b/test/api/load-balancer.test.js
@@ -56,7 +56,7 @@ const mock = {
     },
     proxy_protocol: false
   },
-  getHealthCheckinfo: {
+  getHealthCheckInfo: {
     protocol: 'https',
     port: 80,
     path: '/',

--- a/test/util.js
+++ b/test/util.js
@@ -22,7 +22,6 @@ exports.createTestSuite = (specificationFile, mockData, mockParameters) => {
           }
         }
 
-
         beforeEach(() => {
           if (endpoint.requestType === 'GET') {
             nock(config.baseUrl, endpoint.apiKeyRequired ? config.headers : {})
@@ -55,7 +54,7 @@ exports.createTestSuite = (specificationFile, mockData, mockParameters) => {
 
             vultrInstance[apiModule][key](
               (mockParameters && mockParameters[key]) || {}
-            ).then(response => {
+            ).then((response) => {
               if (mockData[key]) {
                 expect(response).to.deep.equal(mockData[key])
               } else {
@@ -84,13 +83,20 @@ exports.createTestSuite = (specificationFile, mockData, mockParameters) => {
 
           vultrInstance[apiModule][key](
             (mockParameters && mockParameters[key]) || {}
-          ).then(response => {
-            if (mockData[key]) {
-              expect(response).to.deep.equal(mockData[key])
-            } else {
-              expect(response).to.equal(undefined)
-            }
-          })
+          )
+            .then((response) => {
+              if (mockData[key]) {
+                // Response successful and returns data
+                expect(response).to.deep.equal(mockData[key])
+              } else {
+                // Response successful but returns no data
+                expect(response).to.equal(undefined)
+              }
+            })
+            .catch((err) => {
+              console.error(err)
+              return err
+            })
         })
       })
     }

--- a/test/util.js
+++ b/test/util.js
@@ -94,7 +94,6 @@ exports.createTestSuite = (specificationFile, mockData, mockParameters) => {
               }
             })
             .catch((err) => {
-              console.error(err)
               return err
             })
         })


### PR DESCRIPTION
## Description

- Replaces `request` with `node-fetch` due to `request` being deprecated (see: https://github.com/request/request/issues/3142)
- Fixes `getHealthCheckInfo` tests by fixing casing of the mock data to fix the silently failing tests
- Removes comma dangle as default setting in prettier due to upgrade to Prettier 2.X

## Related Issues
Implements #332

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
