### PR TITLE
Change PolyFill to support IOS

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,17 +10,12 @@ exports.makeApiRequest = (config, endpoint, parameters) => {
   }
 
   if (parameters !== undefined) {
-    const params = new URLSearchParams()
-    const userParams = Object.keys(parameters)
-
-    userParams.forEach((key) => {
-      params.append(key, parameters[key])
-    })
+    const userParams = Object.keys(parameters).map((key) => key + '=' + encodeURIComponent(parameters[key])).join('&')
 
     if (endpoint.requestType === 'POST') {
-      options.body = params
+      options.body = userParams
     } else if (endpoint.requestType === 'GET') {
-      fetchUrl = `${fetchUrl}?${params}`
+      fetchUrl = `${fetchUrl}?${userParams}`
     }
   }
 


### PR DESCRIPTION
## Description
IOS does not support URLSearchParams(). Consequently any POST requests ran from an IOS device with this library fail. 

## Related Issues

Fixes Issue 372

### Checklist:

* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ X] Have you linted your code locally prior to submission?
* [ X] Have you successfully ran tests with your changes locally?
