### PR TITLE
#394 adds missing header to POST requests

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,10 +10,13 @@ exports.makeApiRequest = (config, endpoint, parameters) => {
   }
 
   if (parameters !== undefined) {
-    const userParams = Object.keys(parameters).map((key) => key + '=' + encodeURIComponent(parameters[key])).join('&')
+    const userParams = Object.keys(parameters)
+      .map((key) => key + '=' + encodeURIComponent(parameters[key]))
+      .join('&')
 
     if (endpoint.requestType === 'POST') {
       options.body = userParams
+      options.headers['Content-Type'] = 'application/x-www-form-urlencoded'
     } else if (endpoint.requestType === 'GET') {
       fetchUrl = `${fetchUrl}?${userParams}`
     }


### PR DESCRIPTION
## Description
Fixes #394 by adding the header of "Content-Type: application/x-www-form-urlencoded" which was automatically added by the usage of `URLSearchParams()`, but when that was removed in #373, the header was missing and caused an error with POST requests. 

## Related Issues
Fixes #394 , consequence of #373 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
