### PR TITLE
#477 fix formatting in block storage endpoints

### DIFF
--- a/src/api/block-storage.js
+++ b/src/api/block-storage.js
@@ -115,16 +115,19 @@ exports.updateStorage = {
 exports.attachStorage = {
   url: '/blocks/{block-id}/attach',
   requestType: 'POST',
-  'block-id': {
-    type: 'string',
-    path: true,
-    required: true
-  },
-  instance_id: {
-    type: 'string',
-    required: true
-  },
-  live: { type: 'boolean' }
+  apiKeyRequired: true,
+  parameters: {
+    'block-id': {
+      type: 'string',
+      path: true,
+      required: true
+    },
+    instance_id: {
+      type: 'string',
+      required: true
+    },
+    live: { type: 'boolean' }
+  }
 }
 
 /**
@@ -137,10 +140,13 @@ exports.attachStorage = {
 exports.detachStorage = {
   url: '/blocks/{block-id}',
   requestType: 'POST',
-  'block-id': {
-    type: 'string',
-    path: true,
-    required: true
-  },
-  live: { type: 'boolean' }
+  apiKeyRequired: true,
+  parameters: {
+    'block-id': {
+      type: 'string',
+      path: true,
+      required: true
+    },
+    live: { type: 'boolean' }
+  }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Fixes the formatting of the Block Storage endpoints to properly pass their parameters in a parameter object and also add the `apiKeyRequired` flag. 

## Related Issues
Fixes #477 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
