### PR TITLE
(Basic) Typescript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ typings/
 
 #Mac os
 .DS_Store
+
+dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.0"
+        "node-fetch": "^2.6.0",
+        "typescript": "^4.3.5"
       },
       "devDependencies": {
         "@babel/cli": "^7.10.1",
@@ -33,6 +34,8 @@
       "integrity": "sha512-lcy6Lymft9Rpfqmrqdd4oTDdUx9ZwaAhAfywVrHG4771Pa6PPT0danJ1kDHBXYqh4HHSmIdA+nlmfxfxSDPtBg==",
       "dev": true,
       "dependencies": {
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.2",
+        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -3633,6 +3636,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -4311,7 +4315,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6987,6 +6992,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
@@ -10829,8 +10835,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19484,9 +19488,7 @@
     "typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "version": "2.1.1",
   "description": "Node module to communicate with the Vultr API",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "babel src -d dist",
+    "build": "babel src -d dist && tsc",
     "test": "jest",
     "lint": "eslint src",
     "prettier": "prettier --write src",
@@ -43,7 +44,8 @@
     "prettier": "^2.0.5"
   },
   "dependencies": {
-    "node-fetch": "^2.6.0"
+    "node-fetch": "^2.6.0",
+    "typescript": "^4.3.5"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": false,
   "version": "2.1.1",
   "description": "Node module to communicate with the Vultr API",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "build": "babel src -d dist",
     "test": "jest",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "outDir": "./dist",
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
## Description

This adds basic typescript types to the builds. Which helps with autocompletion when using the library.

https://user-images.githubusercontent.com/601961/129335662-540243df-2c42-46fc-b1cb-b8797bd28ba0.mp4

Without rewriting the codebase in TS (perhaps this would be preferable?) or manually creating and tracking types like the @types project does I don't think it'll ever be perfect, but maybe it's a reasonable start?

### Notes

- I noticed that the npm package doesn't include the dist directory? Is this intentional? I changed package main in the PR because that's where the types get saved to, but it'll mean that dist needs to be included.
- Parameters aren't optional in the node code, so TS complains when you do something like `vultr.account.getAccount()` (rather than `vultr.account.getAccount({})`
- Most stuff gets typed to `:any` so TS isn't aware for instance that `vultr.account.getAccount({})` returns a Promise, and therefore doesn't autosuggest `.then()` afterwards

## Related Issues

Addresses #393
### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
