### PR TITLE
#546 add dns_sec to mock response in tests

### DIFF
--- a/test/api/dns.test.js
+++ b/test/api/dns.test.js
@@ -71,7 +71,8 @@ const mockResponses = {
   getDomain: {
     domain: {
       domain: 'vultr.com',
-      date_created: '2020-10-10T01:56:20+00:00'
+      date_created: '2020-10-10T01:56:20+00:00',
+      dns_sec: 'enabled'
     }
   },
   updateDomain: {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
Adds the `dns_sec` flag to the `getDomain` response for DNS. 

## Related Issues
Resolves issue #546 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
