### PR TITLE
#550 fix missing request type in bare-metals, add test case to avoid future issues

### DIFF
--- a/src/api/bare-metal.js
+++ b/src/api/bare-metal.js
@@ -132,7 +132,7 @@ exports.deleteInstance = {
  */
 exports.getInstanceIpv4Addresses = {
   url: '/bare-metals/{baremetal-id}/ipv4',
-  requestType: '',
+  requestType: 'GET',
   apiKeyRequired: true,
   parameters: {
     'baremetal-id': {

--- a/test/util.js
+++ b/test/util.js
@@ -8,6 +8,7 @@ exports.createTestSuite = (specificationFile, mockParameters, mockResponse) => {
   const apiModule = specificationFile.replace(/-([a-z])/g, function (str) {
     return str[1].toUpperCase()
   })
+  const validRequestTypes = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE']
 
   jest.mock('node-fetch', () => jest.fn())
 
@@ -24,6 +25,10 @@ exports.createTestSuite = (specificationFile, mockParameters, mockResponse) => {
             }
           }
         }
+
+        it('has a valid request type', () => {
+          expect(validRequestTypes.includes(endpoint.requestType)).toEqual(true)
+        })
 
         if (endpoint.apiKeyRequired) {
           it('requires an API key', () => {


### PR DESCRIPTION
## Description
There was an API config for `getInstanceIpv4Addresses` that was missing a request type which means that using the endpoint would have failed since it wouldn't know what request type to use. This PR adds the missing request type and adds a test case to avoid this happening in the future. 

## Related Issues
Fixes issue #550 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
