### PR TITLE
#551 add /detach to end of block storage detach url

### DIFF
--- a/src/api/block-storage.js
+++ b/src/api/block-storage.js
@@ -138,7 +138,7 @@ exports.attachStorage = {
  * @instance
  */
 exports.detachStorage = {
-  url: '/blocks/{block-id}',
+  url: '/blocks/{block-id}/detach',
   requestType: 'POST',
   apiKeyRequired: true,
   parameters: {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
The block storage's detachStorage call was missing `/detach` at the end of its request URL

## Related Issues
Fixes #551 

### Checklist:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you linted your code locally prior to submission?
* [X] Have you successfully ran tests with your changes locally?
