### PR TITLE
Include API error message in returned errors

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -59,7 +59,18 @@ exports.makeApiRequest = (config, endpoint, userParameters) => {
     .then((response) => {
       // The request was not successful
       if (!response.ok) {
-        throw Error(response.statusText)
+        return response
+          .json()
+          .catch(() => {
+            throw Error(response.statusText)
+          })
+          .then((json) => {
+            if (json.error) {
+              throw Error(`${response.statusText}: ${json.error}`)
+            } else {
+              throw Error(response.statusText)
+            }
+          })
       }
 
       const contentType = response.headers.get('content-type')


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
The API returns helpful error messages, in case of an error. However, this package doesn't use those error messages, and instead throws an error with the default HTTP error message. This makes debugging the use of this package difficult.

This PR includes the error message returned by the API in the error message thrown by this package, when possible. For example, in the case I was trying to debug, the error message used to be:
```
Error: Bad Request
```
but after this PR is
```
Error: Bad Request: Invalid plan chosen.
```
which is significantly more helpful when debugging my code.

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
